### PR TITLE
Adding loguru which is in pipelines/kfp_helper.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ kfp-kubernetes==1.2.0; python_full_version < '3.13.0' and python_full_version >=
 kfp-pipeline-spec==0.3.0; python_full_version < '3.13.0' and python_full_version >= '3.7.0'
 kfp-server-api==2.0.5
 kubernetes==26.1.0; python_version >= '3.6'
+loguru==0.7.3
 mpmath==1.3.0
 numpy==1.26.4; python_version >= '3.9'
 oauthlib==3.2.2; python_version >= '3.6'


### PR DESCRIPTION
I was doing tests with `pipelines/11_iris_training_pipeline.py` on a fresh environment, and saw that `loguru` in `pipelines/kfp_helper.py` is imported but not mentioned in the requirements file.